### PR TITLE
build.sbt pakage versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,19 @@ You can launch a prediction WebAPI service without any coding.
 
 ## Prerequisites
 
-- Apache PredictionIO 0.14.0 or higher
-- Apache Spark 2.4.0 or higher
+- Apache PredictionIO 0.14.0
+- Apache Spark 2.3.2
+- Java 1.8
+- TransmogrifAI 0.6.0
+- Scala 2.11.12
+
+- Make sure you compile PredictionIO with the correct scala & spark version (check out [detailed instructions](http://predictionio.apache.org/install/install-sourcecode/)): 
+
+    ```bash
+    $ ./make-distribution.sh -Dscala.version=2.11.12 -Dspark.version=2.3.2
+    ```
+
+__NOTE__: if the compilation fails due to cache problems, you may want to manually remove `~/.ivy2` folder and try again.
 
 ## Run Titanic example
 
@@ -38,6 +49,11 @@ Import data to the event server.
 
 ```bash
 $ python ./data/import_titanic.py --file ./data/titanic.csv --access_key $ACCESS_KEY
+```
+
+Build the app
+```bash
+$ pio build --verbose
 ```
 
 Train a model. It can take a long time to find the best model.

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,19 @@
 name := "template-scala-automl"
 
 scalaVersion := "2.11.12"
+val sparkV = "2.3.2"
+val aiV = "0.6.0"
 
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % "0.14.0" % "provided",
-  "org.apache.spark"        %% "spark-mllib"              % "2.4.0" % "provided",
-  "com.salesforce.transmogrifai" %% "transmogrifai-core" % "0.5.3" excludeAll(
+  "org.apache.spark"        %% "spark-mllib"              % sparkV % "provided",
+  "com.salesforce.transmogrifai" %% "transmogrifai-core" % aiV excludeAll(
     ExclusionRule(organization = "org.apache.spark")
   ),
-  "com.salesforce.transmogrifai" %% "transmogrifai-local" % "0.5.3" excludeAll(
+  "com.salesforce.transmogrifai" %% "transmogrifai-local" % aiV excludeAll(
     ExclusionRule(organization = "org.apache.spark")
   ),
-  "com.salesforce.transmogrifai" %% "transmogrifai-features" % "0.5.3"  excludeAll(
+  "com.salesforce.transmogrifai" %% "transmogrifai-features" % aiV  excludeAll(
     ExclusionRule(organization = "org.apache.spark")
   ),
   "org.scalatest"           %% "scalatest"                % "3.0.5" % "test")
@@ -24,3 +26,4 @@ assemblyMergeStrategy in assembly := {
   case "reference.conf"       => MergeStrategy.concat
   case _                      => MergeStrategy.first
 }
+


### PR DESCRIPTION
In order to avoid `Exception in thread "main" java.lang.AbstractMethodError` (issue #10), define new package version prerequisites.